### PR TITLE
moves from tree type the map of trees by http verb to the router type

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -11,21 +11,17 @@ const (
 )
 
 type Tree struct {
-	root map[string]*Node
+	root *Node
 }
 
-func (t *Tree) Insert(verb string, chunks []chunk, handler HandlerFunction) {
+func (t *Tree) Insert(chunks []chunk, handler HandlerFunction) {
 
 	subtree, err := createTreeFromChunks(chunks, handler)
 	if err != nil {
 		panic(err)
 	}
 
-	if nil == t.root {
-		t.root = make(map[string]*Node)
-	}
-
-	t.root[verb] = combine(t.root[verb], subtree)
+	t.root = combine(t.root, subtree)
 }
 
 func combine(tree1 *Node, tree2 *Node) *Node {
@@ -135,16 +131,10 @@ func createNodeFromChunk(c chunk) *Node {
 	return n
 }
 
-func (t *Tree) Find(verb string, path string) (HandlerFunction, UrlParameterBag) {
+func (t *Tree) Find(path string) (HandlerFunction, UrlParameterBag) {
 	urlParameterBag := NewUrlParameterBag(5, true)
 
-	n, ok := t.root[verb]
-	if !ok {
-		return nil, urlParameterBag
-	}
-	p := path
-
-	return find(n, p, &urlParameterBag), urlParameterBag
+	return find(t.root, path, &urlParameterBag), urlParameterBag
 }
 
 func find(n *Node, p string, urlParameterBag *UrlParameterBag) HandlerFunction {

--- a/tree_test.go
+++ b/tree_test.go
@@ -22,23 +22,23 @@ func generateDynamicChunk(ident string, regExp *regexp.Regexp) []chunk {
 
 func TestInsertOnEmptyTree(t *testing.T) {
 	tree := Tree{}
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1"), nil)
+	tree.Insert(generateStaticChunk("/path1"), nil)
 
-	if "/path1" != tree.root[http.MethodGet].prefix {
+	if "/path1" != tree.root.prefix {
 		t.Errorf("")
 	}
 }
 
 func TestInsertChild(t *testing.T) {
 	tree := Tree{}
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1"), nil)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1/path2"), nil)
+	tree.Insert(generateStaticChunk("/path1"), nil)
+	tree.Insert(generateStaticChunk("/path1/path2"), nil)
 
-	if "/path1" != tree.root[http.MethodGet].prefix {
+	if "/path1" != tree.root.prefix {
 		t.Errorf("")
 	}
 
-	if "/path2" != tree.root[http.MethodGet].child.prefix {
+	if "/path2" != tree.root.child.prefix {
 		t.Errorf("")
 	}
 }
@@ -48,20 +48,20 @@ func TestInsertDynamicChild(t *testing.T) {
 	h := func(res http.ResponseWriter, req *http.Request) {}
 
 	tree := Tree{}
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1/"), nil)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/"), generateDynamicChunk("id", nil)...), h)
+	tree.Insert(generateStaticChunk("/path1/"), nil)
+	tree.Insert(append(generateStaticChunk("/path1/"), generateDynamicChunk("id", nil)...), h)
 
-	if "/path1/" != tree.root[http.MethodGet].prefix {
+	if "/path1/" != tree.root.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].t {
+	if NodeTypeStatic != tree.root.t {
 		t.Errorf("")
 	}
 
-	if "id" != tree.root[http.MethodGet].child.prefix {
+	if "id" != tree.root.child.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeDynamic != tree.root[http.MethodGet].child.t {
+	if NodeTypeDynamic != tree.root.child.t {
 		t.Errorf("")
 	}
 }
@@ -71,23 +71,23 @@ func TestInsertDynamicChildWithRegularExpression(t *testing.T) {
 	h := func(res http.ResponseWriter, req *http.Request) {}
 
 	tree := Tree{}
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1/"), nil)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/"), generateDynamicChunk("id", regexp.MustCompile("[0-9]+"))...), h)
+	tree.Insert(generateStaticChunk("/path1/"), nil)
+	tree.Insert(append(generateStaticChunk("/path1/"), generateDynamicChunk("id", regexp.MustCompile("[0-9]+"))...), h)
 
-	if "/path1/" != tree.root[http.MethodGet].prefix {
+	if "/path1/" != tree.root.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].t {
+	if NodeTypeStatic != tree.root.t {
 		t.Errorf("")
 	}
 
-	if "id" != tree.root[http.MethodGet].child.prefix {
+	if "id" != tree.root.child.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeDynamic != tree.root[http.MethodGet].child.t {
+	if NodeTypeDynamic != tree.root.child.t {
 		t.Errorf("")
 	}
-	if "[0-9]+" != tree.root[http.MethodGet].child.regexp.String() {
+	if "[0-9]+" != tree.root.child.regexp.String() {
 		t.Errorf("")
 	}
 }
@@ -97,27 +97,27 @@ func TestInsertDynamicChildHasNoHandler(t *testing.T) {
 	h := func(res http.ResponseWriter, req *http.Request) {}
 
 	tree := Tree{}
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1/"), nil)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", regexp.MustCompile("[0-9]{4}-[0-9]{2}-[0-9]{2}")), generateStaticChunk("/")...)...), h)
+	tree.Insert(generateStaticChunk("/path1/"), nil)
+	tree.Insert(append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", regexp.MustCompile("[0-9]{4}-[0-9]{2}-[0-9]{2}")), generateStaticChunk("/")...)...), h)
 
-	if "/path1/" != tree.root[http.MethodGet].prefix {
+	if "/path1/" != tree.root.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].t {
-		t.Errorf("")
-	}
-
-	if "id" != tree.root[http.MethodGet].child.prefix {
-		t.Errorf("")
-	}
-	if NodeTypeDynamic != tree.root[http.MethodGet].child.t {
-		t.Errorf("")
-	}
-	if "[0-9]{4}-[0-9]{2}-[0-9]{2}" != tree.root[http.MethodGet].child.regexp.String() {
+	if NodeTypeStatic != tree.root.t {
 		t.Errorf("")
 	}
 
-	child, ok := tree.root[http.MethodGet].child.stops['/']
+	if "id" != tree.root.child.prefix {
+		t.Errorf("")
+	}
+	if NodeTypeDynamic != tree.root.child.t {
+		t.Errorf("")
+	}
+	if "[0-9]{4}-[0-9]{2}-[0-9]{2}" != tree.root.child.regexp.String() {
+		t.Errorf("")
+	}
+
+	child, ok := tree.root.child.stops['/']
 
 	if !ok {
 		t.Errorf("")
@@ -138,31 +138,31 @@ func TestInsertDynamicChildHasNoHandlerWithSiblings(t *testing.T) {
 	h := func(res http.ResponseWriter, req *http.Request) {}
 
 	tree := Tree{}
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1/"), nil)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", nil), generateStaticChunk("/")...)...), h)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", nil), generateStaticChunk("-")...)...), h)
+	tree.Insert(generateStaticChunk("/path1/"), nil)
+	tree.Insert(append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", nil), generateStaticChunk("/")...)...), h)
+	tree.Insert(append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", nil), generateStaticChunk("-")...)...), h)
 
-	if "/path1/" != tree.root[http.MethodGet].prefix {
+	if "/path1/" != tree.root.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].t {
-		t.Errorf("")
-	}
-
-	if "id" != tree.root[http.MethodGet].child.prefix {
-		t.Errorf("")
-	}
-	if NodeTypeDynamic != tree.root[http.MethodGet].child.t {
+	if NodeTypeStatic != tree.root.t {
 		t.Errorf("")
 	}
 
-	if len(tree.root[http.MethodGet].child.stops) != 2 {
+	if "id" != tree.root.child.prefix {
+		t.Errorf("")
+	}
+	if NodeTypeDynamic != tree.root.child.t {
+		t.Errorf("")
+	}
+
+	if len(tree.root.child.stops) != 2 {
 		t.Errorf("")
 	}
 
 	var child, sibling *Node
 
-	child, ok := tree.root[http.MethodGet].child.stops['/']
+	child, ok := tree.root.child.stops['/']
 
 	if !ok {
 		t.Errorf("")
@@ -176,7 +176,7 @@ func TestInsertDynamicChildHasNoHandlerWithSiblings(t *testing.T) {
 		t.Errorf("")
 	}
 
-	sibling, ok = tree.root[http.MethodGet].child.stops['-']
+	sibling, ok = tree.root.child.stops['-']
 
 	if !ok {
 		t.Errorf("")
@@ -194,58 +194,58 @@ func TestInsertDynamicChildHasNoHandlerWithSiblings(t *testing.T) {
 func TestInsertHandlerIsOnlyOnLeaf(t *testing.T) {
 	tree := Tree{}
 	h := func(w http.ResponseWriter, r *http.Request) {}
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1")), h)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/path2")), h)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/path2/path3")), h)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/path2/path4")), h)
+	tree.Insert(append(generateStaticChunk("/path1")), h)
+	tree.Insert(append(generateStaticChunk("/path1/path2")), h)
+	tree.Insert(append(generateStaticChunk("/path1/path2/path3")), h)
+	tree.Insert(append(generateStaticChunk("/path1/path2/path4")), h)
 
-	if "/path1" != tree.root[http.MethodGet].prefix {
+	if "/path1" != tree.root.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].t {
+	if NodeTypeStatic != tree.root.t {
 		t.Errorf("")
 	}
-	if nil == tree.root[http.MethodGet].handler {
-		t.Errorf("")
-	}
-
-	if "/path2" != tree.root[http.MethodGet].child.prefix {
-		t.Errorf("")
-	}
-	if NodeTypeStatic != tree.root[http.MethodGet].child.t {
-		t.Errorf("")
-	}
-	if nil == tree.root[http.MethodGet].child.handler {
+	if nil == tree.root.handler {
 		t.Errorf("")
 	}
 
-	if "/path" != tree.root[http.MethodGet].child.child.prefix {
+	if "/path2" != tree.root.child.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].child.child.t {
+	if NodeTypeStatic != tree.root.child.t {
 		t.Errorf("")
 	}
-	if nil != tree.root[http.MethodGet].child.child.handler {
-		t.Errorf("")
-	}
-
-	if "3" != tree.root[http.MethodGet].child.child.child.prefix {
-		t.Errorf("")
-	}
-	if NodeTypeStatic != tree.root[http.MethodGet].child.child.child.t {
-		t.Errorf("")
-	}
-	if nil == tree.root[http.MethodGet].child.child.child.handler {
+	if nil == tree.root.child.handler {
 		t.Errorf("")
 	}
 
-	if "4" != tree.root[http.MethodGet].child.child.child.sibling.prefix {
+	if "/path" != tree.root.child.child.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].child.child.child.sibling.t {
+	if NodeTypeStatic != tree.root.child.child.t {
 		t.Errorf("")
 	}
-	if nil == tree.root[http.MethodGet].child.child.child.sibling.handler {
+	if nil != tree.root.child.child.handler {
+		t.Errorf("")
+	}
+
+	if "3" != tree.root.child.child.child.prefix {
+		t.Errorf("")
+	}
+	if NodeTypeStatic != tree.root.child.child.child.t {
+		t.Errorf("")
+	}
+	if nil == tree.root.child.child.child.handler {
+		t.Errorf("")
+	}
+
+	if "4" != tree.root.child.child.child.sibling.prefix {
+		t.Errorf("")
+	}
+	if NodeTypeStatic != tree.root.child.child.child.sibling.t {
+		t.Errorf("")
+	}
+	if nil == tree.root.child.child.child.sibling.handler {
 		t.Errorf("")
 	}
 }
@@ -253,100 +253,100 @@ func TestInsertHandlerIsOnlyOnLeaf(t *testing.T) {
 func TestInsertHandlerNotRemovePreviousHandler(t *testing.T) {
 	tree := Tree{}
 	h := func(w http.ResponseWriter, r *http.Request) {}
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/"), generateDynamicChunk("id", nil)...), h)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", nil), generateStaticChunk("/path2")...)...), h)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", nil), generateStaticChunk("/path3")...)...), h)
-	tree.Insert(http.MethodGet, append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", nil), generateStaticChunk("/path2/path4")...)...), h)
+	tree.Insert(append(generateStaticChunk("/path1/"), generateDynamicChunk("id", nil)...), h)
+	tree.Insert(append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", nil), generateStaticChunk("/path2")...)...), h)
+	tree.Insert(append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", nil), generateStaticChunk("/path3")...)...), h)
+	tree.Insert(append(generateStaticChunk("/path1/"), append(generateDynamicChunk("id", nil), generateStaticChunk("/path2/path4")...)...), h)
 
-	if "/path1/" != tree.root[http.MethodGet].prefix {
+	if "/path1/" != tree.root.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].t {
+	if NodeTypeStatic != tree.root.t {
 		t.Errorf("")
 	}
-	if nil != tree.root[http.MethodGet].handler {
-		t.Errorf("")
-	}
-
-	if "id" != tree.root[http.MethodGet].child.prefix {
-		t.Errorf("")
-	}
-	if NodeTypeDynamic != tree.root[http.MethodGet].child.t {
-		t.Errorf("")
-	}
-	if nil == tree.root[http.MethodGet].child.handler {
+	if nil != tree.root.handler {
 		t.Errorf("")
 	}
 
-	if "/path" != tree.root[http.MethodGet].child.child.prefix {
+	if "id" != tree.root.child.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].child.child.t {
+	if NodeTypeDynamic != tree.root.child.t {
 		t.Errorf("")
 	}
-	if nil != tree.root[http.MethodGet].child.child.handler {
-		t.Errorf("")
-	}
-
-	if "2" != tree.root[http.MethodGet].child.child.child.prefix {
-		t.Errorf("")
-	}
-	if NodeTypeStatic != tree.root[http.MethodGet].child.child.child.t {
-		t.Errorf("")
-	}
-	if nil == tree.root[http.MethodGet].child.child.child.handler {
+	if nil == tree.root.child.handler {
 		t.Errorf("")
 	}
 
-	if "3" != tree.root[http.MethodGet].child.child.child.sibling.prefix {
+	if "/path" != tree.root.child.child.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].child.child.child.sibling.t {
+	if NodeTypeStatic != tree.root.child.child.t {
 		t.Errorf("")
 	}
-	if nil == tree.root[http.MethodGet].child.child.child.sibling.handler {
+	if nil != tree.root.child.child.handler {
 		t.Errorf("")
 	}
 
-	if "/path4" != tree.root[http.MethodGet].child.child.child.child.prefix {
+	if "2" != tree.root.child.child.child.prefix {
 		t.Errorf("")
 	}
-	if NodeTypeStatic != tree.root[http.MethodGet].child.child.child.child.t {
+	if NodeTypeStatic != tree.root.child.child.child.t {
 		t.Errorf("")
 	}
-	if nil == tree.root[http.MethodGet].child.child.child.child.handler {
+	if nil == tree.root.child.child.child.handler {
+		t.Errorf("")
+	}
+
+	if "3" != tree.root.child.child.child.sibling.prefix {
+		t.Errorf("")
+	}
+	if NodeTypeStatic != tree.root.child.child.child.sibling.t {
+		t.Errorf("")
+	}
+	if nil == tree.root.child.child.child.sibling.handler {
+		t.Errorf("")
+	}
+
+	if "/path4" != tree.root.child.child.child.child.prefix {
+		t.Errorf("")
+	}
+	if NodeTypeStatic != tree.root.child.child.child.child.t {
+		t.Errorf("")
+	}
+	if nil == tree.root.child.child.child.child.handler {
 		t.Errorf("")
 	}
 }
 
 func TestInsertSibling(t *testing.T) {
 	tree := Tree{}
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1"), nil)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path2"), nil)
+	tree.Insert(generateStaticChunk("/path1"), nil)
+	tree.Insert(generateStaticChunk("/path2"), nil)
 
-	if "/path" != tree.root[http.MethodGet].prefix {
+	if "/path" != tree.root.prefix {
 		t.Errorf("")
 	}
 
-	if "1" != tree.root[http.MethodGet].child.prefix {
+	if "1" != tree.root.child.prefix {
 		t.Errorf("")
 	}
 
-	if "2" != tree.root[http.MethodGet].child.sibling.prefix {
+	if "2" != tree.root.child.sibling.prefix {
 		t.Errorf("")
 	}
 }
 
 func TestInsertSiblingNoCommon(t *testing.T) {
 	tree := Tree{}
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1"), nil)
-	tree.Insert(http.MethodGet, generateStaticChunk("path2"), nil)
+	tree.Insert(generateStaticChunk("/path1"), nil)
+	tree.Insert(generateStaticChunk("path2"), nil)
 
-	if "/path1" != tree.root[http.MethodGet].prefix {
+	if "/path1" != tree.root.prefix {
 		t.Errorf("")
 	}
 
-	if "path2" != tree.root[http.MethodGet].sibling.prefix {
+	if "path2" != tree.root.sibling.prefix {
 		t.Errorf("")
 	}
 
@@ -354,46 +354,46 @@ func TestInsertSiblingNoCommon(t *testing.T) {
 
 func TestInsertChildOnSibling(t *testing.T) {
 	tree := Tree{}
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1"), nil)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path2"), nil)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1/path3"), nil)
+	tree.Insert(generateStaticChunk("/path1"), nil)
+	tree.Insert(generateStaticChunk("/path2"), nil)
+	tree.Insert(generateStaticChunk("/path1/path3"), nil)
 
-	if "/path" != tree.root[http.MethodGet].prefix {
+	if "/path" != tree.root.prefix {
 		t.Errorf("")
 	}
 
-	if "1" != tree.root[http.MethodGet].child.prefix {
+	if "1" != tree.root.child.prefix {
 		t.Errorf("")
 	}
 
-	if "2" != tree.root[http.MethodGet].child.sibling.prefix {
+	if "2" != tree.root.child.sibling.prefix {
 		t.Errorf("")
 	}
 
-	if "/path3" != tree.root[http.MethodGet].child.child.prefix {
+	if "/path3" != tree.root.child.child.prefix {
 		t.Errorf("")
 	}
 }
 
 func TestInsertSiblingOnSibling(t *testing.T) {
 	tree := Tree{}
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1"), nil)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path2"), nil)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path3"), nil)
+	tree.Insert(generateStaticChunk("/path1"), nil)
+	tree.Insert(generateStaticChunk("/path2"), nil)
+	tree.Insert(generateStaticChunk("/path3"), nil)
 
-	if "/path" != tree.root[http.MethodGet].prefix {
+	if "/path" != tree.root.prefix {
 		t.Errorf("")
 	}
 
-	if "1" != tree.root[http.MethodGet].child.prefix {
+	if "1" != tree.root.child.prefix {
 		t.Errorf("")
 	}
 
-	if "2" != tree.root[http.MethodGet].child.sibling.prefix {
+	if "2" != tree.root.child.sibling.prefix {
 		t.Errorf("")
 	}
 
-	if "3" != tree.root[http.MethodGet].child.sibling.sibling.prefix {
+	if "3" != tree.root.child.sibling.sibling.prefix {
 		t.Errorf("")
 	}
 }
@@ -405,17 +405,17 @@ func TestInsertWithHandler(t *testing.T) {
 	handler3, _ := generateHandler("/path3")
 	handler4, flag4 := generateHandler("/path3/path4")
 	handler5, _ := generateHandler("/path5/path4")
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1"), handler1)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path2"), handler2)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path3"), handler3)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path3/path4"), handler4)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path4/path5"), handler5)
+	tree.Insert(generateStaticChunk("/path1"), handler1)
+	tree.Insert(generateStaticChunk("/path2"), handler2)
+	tree.Insert(generateStaticChunk("/path3"), handler3)
+	tree.Insert(generateStaticChunk("/path3/path4"), handler4)
+	tree.Insert(generateStaticChunk("/path4/path5"), handler5)
 
-	if nil != tree.root[http.MethodGet].handler {
+	if nil != tree.root.handler {
 		t.Errorf("")
 	}
 
-	handler := tree.root[http.MethodGet].child.handler
+	handler := tree.root.child.handler
 	if nil == handler {
 		t.Errorf("")
 	}
@@ -424,15 +424,15 @@ func TestInsertWithHandler(t *testing.T) {
 		t.Errorf("")
 	}
 
-	if nil == tree.root[http.MethodGet].child.sibling.handler {
+	if nil == tree.root.child.sibling.handler {
 		t.Errorf("")
 	}
 
-	if nil == tree.root[http.MethodGet].child.sibling.sibling.handler {
+	if nil == tree.root.child.sibling.sibling.handler {
 		t.Errorf("")
 	}
 
-	handler = tree.root[http.MethodGet].child.sibling.sibling.child.handler
+	handler = tree.root.child.sibling.sibling.child.handler
 	if nil == handler {
 		t.Errorf("")
 	}
@@ -441,7 +441,7 @@ func TestInsertWithHandler(t *testing.T) {
 		t.Errorf("")
 	}
 
-	if nil == tree.root[http.MethodGet].child.sibling.sibling.sibling.handler {
+	if nil == tree.root.child.sibling.sibling.sibling.handler {
 		t.Errorf("")
 	}
 
@@ -454,13 +454,13 @@ func TestFindHandler(t *testing.T) {
 	handler3, _ := generateHandler("/path3")
 	handler4, flag4 := generateHandler("/path3/path4")
 	handler5, _ := generateHandler("/path5/path4")
-	tree.Insert(http.MethodGet, generateStaticChunk("/path1"), handler1)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path2"), handler2)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path3"), handler3)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path3/path4"), handler4)
-	tree.Insert(http.MethodGet, generateStaticChunk("/path4/path5"), handler5)
+	tree.Insert(generateStaticChunk("/path1"), handler1)
+	tree.Insert(generateStaticChunk("/path2"), handler2)
+	tree.Insert(generateStaticChunk("/path3"), handler3)
+	tree.Insert(generateStaticChunk("/path3/path4"), handler4)
+	tree.Insert(generateStaticChunk("/path4/path5"), handler5)
 
-	handler, paramBag := tree.Find(http.MethodGet, "/path3/path4")
+	handler, paramBag := tree.Find("/path3/path4")
 	handler(nil, nil)
 
 	if *flag4 != "/path3/path4" {
@@ -499,35 +499,35 @@ func TestFindHandlerWithDynamic(t *testing.T) {
 
 	parser := NewParser("/path1/{id}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler1)
+	tree.Insert(parser.chunks, handler1)
 
 	parser = NewParser("/path1/{id}/path2")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler2)
+	tree.Insert(parser.chunks, handler2)
 
 	parser = NewParser("/path1/{id}-path2")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler3)
+	tree.Insert(parser.chunks, handler3)
 
 	parser = NewParser("/path1/{name}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler4)
+	tree.Insert(parser.chunks, handler4)
 
 	parser = NewParser("/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler5)
+	tree.Insert(parser.chunks, handler5)
 
 	parser = NewParser("/path3/{slug}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler6)
+	tree.Insert(parser.chunks, handler6)
 
 	parser = NewParser("/path4/{id:[0-9]+}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler7)
+	tree.Insert(parser.chunks, handler7)
 
 	parser = NewParser("/path4/{id:[0-9]+}/{slug:[a-z]+}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler8)
+	tree.Insert(parser.chunks, handler8)
 
 	data := []findResult{
 		{path: "/path4/1s2a3", ok: false, f: nil},
@@ -548,7 +548,7 @@ func TestFindHandlerWithDynamic(t *testing.T) {
 	}
 
 	for _, item := range data {
-		handler, _ := tree.Find(http.MethodGet, item.path)
+		handler, _ := tree.Find(item.path)
 
 		if handler != nil {
 			if item.ok == false {
@@ -575,16 +575,16 @@ func TestFindHandlerWithDynamicAndParameters(t *testing.T) {
 
 	parser := NewParser("/path1/{id}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, h)
+	tree.Insert(parser.chunks, h)
 	parser = NewParser("/path1/{id}/path2/{slug}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, h)
+	tree.Insert(parser.chunks, h)
 	parser = NewParser("/path1")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, h)
+	tree.Insert(parser.chunks, h)
 	parser = NewParser("/data1/{id}/data2/{id}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, h)
+	tree.Insert(parser.chunks, h)
 
 	data := []findResultWithParams{
 		{path: "/path1/123", ok: true, keys: []string{"id"}, values: []string{"123"}},
@@ -595,7 +595,7 @@ func TestFindHandlerWithDynamicAndParameters(t *testing.T) {
 	}
 
 	for _, item := range data {
-		_, paramBag := tree.Find(http.MethodGet, item.path)
+		_, paramBag := tree.Find(item.path)
 
 		if len(paramBag.params) != len(item.values) {
 			t.Errorf("")
@@ -655,18 +655,18 @@ func TestInsertPrioritisesStaticPaths(t *testing.T) {
 
 	parser := NewParser("/{id}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler)
+	tree.Insert(parser.chunks, handler)
 	parser = NewParser("/{name}")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler)
+	tree.Insert(parser.chunks, handler)
 	parser = NewParser("/path1")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler)
+	tree.Insert(parser.chunks, handler)
 	parser = NewParser("/path2")
 	_, _ = parser.parse()
-	tree.Insert(http.MethodGet, parser.chunks, handler)
+	tree.Insert(parser.chunks, handler)
 
-	node := tree.root[http.MethodGet]
+	node := tree.root
 	if nil != node.handler {
 		t.Errorf("")
 	}


### PR DESCRIPTION
It makes no sense to have a map of trees (one for every http verb) on the Tree type. This is actually something that should be part of the router so this task does exactly that moving the map form one type to the other.