### PR TITLE
chore: limits dynamic nodes to capture variables inside URL chunks delimited by slash

### DIFF
--- a/node.go
+++ b/node.go
@@ -1,0 +1,39 @@
+package routing
+
+import (
+	"net/http"
+	"regexp"
+)
+
+const (
+	catchAllExpression = "^.*$"
+)
+
+type node struct {
+	prefix  string
+	handler http.HandlerFunc
+	child   *node
+	sibling *node
+	t       int
+	stops   map[byte]*node
+	regexp  *regexp.Regexp
+}
+
+func (n *node) isCatchAll() bool {
+	return n.regexpToString() == catchAllExpression
+}
+
+func (n *node) regexpEquals(o *node) bool {
+	return n.regexpToString() == o.regexpToString()
+}
+
+func (n *node) regexpToString() string {
+	if n.t != nodeTypeDynamic {
+		return ""
+	}
+
+	if n.regexp == nil {
+		return ""
+	}
+	return n.regexp.String()
+}

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,63 @@
+package routing
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestRegexpToStringWorks(t *testing.T) {
+
+	node1 := node{t: nodeTypeStatic}
+	if node1.regexpToString() != "" {
+		t.Errorf("Node Type static returns invalid string")
+	}
+
+	node2 := node{t: nodeTypeDynamic, regexp: nil}
+	if node2.regexpToString() != "" {
+		t.Errorf("Node without reg expression returns invalid string")
+	}
+
+	node3 := node{t: nodeTypeDynamic, regexp: regexp.MustCompile("[0-9]+")}
+	if node3.regexpToString() != "[0-9]+" {
+		t.Errorf("Node with regular expression returns invalid string")
+	}
+
+}
+
+func TestIsCatchAllWorks(t *testing.T) {
+
+	node1 := node{t: nodeTypeStatic}
+	if node1.isCatchAll() {
+		t.Errorf("Node Type static is catch all")
+	}
+
+	node2 := node{t: nodeTypeDynamic, regexp: nil}
+	if node2.isCatchAll() {
+		t.Errorf("Node without reg expression is catch all")
+	}
+
+	node3 := node{t: nodeTypeDynamic, regexp: regexp.MustCompile("[0-9]+")}
+	if node3.isCatchAll() {
+		t.Errorf("Node with no catch all regexp is catch all")
+	}
+
+	node4 := node{t: nodeTypeDynamic, regexp: regexp.MustCompile(catchAllExpression)}
+	if !node4.isCatchAll() {
+		t.Errorf("Node with valid catch all expression is not catch all")
+	}
+}
+
+func TestRegexpEqualsWorks(t *testing.T) {
+
+	node1 := node{t: nodeTypeDynamic, regexp: regexp.MustCompile("[a-z]+")}
+	node2 := node{t: nodeTypeDynamic, regexp: regexp.MustCompile("[0-9]+")}
+	node3 := node{t: nodeTypeDynamic, regexp: regexp.MustCompile("[0-9]+")}
+
+	if node1.regexpEquals(&node2) {
+		t.Errorf("Node1 is equal to node 2")
+	}
+
+	if !node2.regexpEquals(&node3) {
+		t.Errorf("Node2 is not equal to node 3")
+	}
+}

--- a/tree_test.go
+++ b/tree_test.go
@@ -513,9 +513,10 @@ func TestFindHandlerWithDynamic(t *testing.T) {
 	handler1, flag1 := generateHandler("/path1/{id}")
 	handler2, flag2 := generateHandler("/path1/{id}/path2")
 	handler3, flag3 := generateHandler("/path1/{id}-path2")
-	handler4, flag4 := generateHandler("/path1/{name}")
+	handler4, flag4 := generateHandler("/path1/{name}/")
 	handler5, flag5 := generateHandler("/{date}")
-	handler6, flag6 := generateHandler("/path3/{slug}")
+	handler6A, flag6A := generateHandler("/path3/{slug:[0-9]+}")
+	handler6B, flag6B := generateHandler("/path3/{slug:.*}")
 	handler7, flag7 := generateHandler("/path4/{id:[0-9]+}")
 	handler8, flag8 := generateHandler("/path4/{id:[0-9]+}/{slug:[a-z]+}")
 
@@ -533,7 +534,7 @@ func TestFindHandlerWithDynamic(t *testing.T) {
 	_, _ = parser.parse()
 	tree.insert(parser.chunks, handler3)
 
-	parser = newParser("/path1/{name}")
+	parser = newParser("/path1/{name}/")
 	_, _ = parser.parse()
 	tree.insert(parser.chunks, handler4)
 
@@ -541,9 +542,13 @@ func TestFindHandlerWithDynamic(t *testing.T) {
 	_, _ = parser.parse()
 	tree.insert(parser.chunks, handler5)
 
-	parser = newParser("/path3/{slug}")
+	parser = newParser("/path3/{slug:[0-9]+}")
 	_, _ = parser.parse()
-	tree.insert(parser.chunks, handler6)
+	tree.insert(parser.chunks, handler6A)
+
+	parser = newParser("/path3/{slug:.*}")
+	_, _ = parser.parse()
+	tree.insert(parser.chunks, handler6B)
 
 	parser = newParser("/path4/{id:[0-9]+}")
 	_, _ = parser.parse()
@@ -556,14 +561,14 @@ func TestFindHandlerWithDynamic(t *testing.T) {
 	data := []findResult{
 		{path: "/path4/1s2a3", ok: false, f: nil},
 		{path: "/path1/123", ok: true, f: flag1, schema: "/path1/{id}"},
-		{path: "/path1/123/", ok: true, f: flag4, schema: "/path1/{name}"},
+		{path: "/path1/123/", ok: true, f: flag4, schema: "/path1/{name}/"},
 		{path: "/path1/123/path2", ok: true, f: flag2, schema: "/path1/{id}/path2"},
 		{path: "/path1/123-path2", ok: true, f: flag3, schema: "/path1/{id}-path2"},
 		{path: "/path1/pepe", ok: true, f: flag1, schema: "/path1/{id}"},
 		{path: "/path1/pepe_path2", ok: true, f: flag1, schema: "/path1/{id}"}, //two siblings dynamic not allowed
 		{path: "/2019-20-11", ok: true, f: flag5, schema: "/{date}"},
-		{path: "/path3/123", ok: true, f: flag6, schema: "/path3/{slug}"},
-		{path: "/path3/123/asdf", ok: true, f: flag6, schema: "/path3/{slug}"},
+		{path: "/path3/123", ok: true, f: flag6A, schema: "/path3/{slug:[0-9]+}"},
+		{path: "/path3/123/asdf", ok: true, f: flag6B, schema: "/path3/{slug:.*}"},
 		{path: "/", ok: false, f: nil},
 
 		{path: "/path4/123", ok: true, f: flag7, schema: "/path4/{id:[0-9]+}"},


### PR DESCRIPTION
Limits dynamic nodes to capture variables inside URL chunks delimited by slash
Allows catch-all dynamic nodes by using a specific regular expression

Signed-off-by: Santiago Garcia <sangarbe@gmail.com>
Co-authored-by: Santiago Garcia <sangarbe@gmail.com>