### PR TITLE
Extracts url parameters on demand

### DIFF
--- a/node.go
+++ b/node.go
@@ -13,6 +13,7 @@ type node struct {
 	prefix  string
 	handler http.HandlerFunc
 	child   *node
+	parent  *node
 	sibling *node
 	t       int
 	stops   map[byte]*node

--- a/tree_test.go
+++ b/tree_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
@@ -19,7 +20,13 @@ func parseAndInsertSchema(tree *tree, schema, prefixHandler string) {
 	tree.insert(parser.chunks, nodePrefixHandler(prefixHandler))
 }
 
-func assertNodeValid(t *testing.T, node *node, nodeType int, prefix string, hasHandler bool) {
+func assertNodeRelative(t *testing.T, childNode *node, parentNode *node) {
+	if !reflect.DeepEqual(childNode.parent, parentNode) {
+		t.Errorf("parent node of child %s is not equal to node %s", childNode.prefix, parentNode.prefix)
+	}
+}
+
+func assertNodeValid(t *testing.T, node *node, nodeType int, prefix string, hasHandler bool, parentNode *node) {
 	if nodeType != node.t {
 		t.Errorf("node prefix %s is not static", prefix)
 	}
@@ -43,14 +50,16 @@ func assertNodeValid(t *testing.T, node *node, nodeType int, prefix string, hasH
 			t.Errorf("invalid handler in node prefix %s", node.prefix)
 		}
 	}
+
+	assertNodeRelative(t, node, parentNode)
 }
 
-func assertNodeStatic(t *testing.T, node *node, prefix string, hasHandler bool) {
-	assertNodeValid(t, node, nodeTypeStatic, prefix, hasHandler)
+func assertNodeStatic(t *testing.T, node *node, prefix string, hasHandler bool, parentNode *node) {
+	assertNodeValid(t, node, nodeTypeStatic, prefix, hasHandler, parentNode)
 }
 
-func assertNodeDynamic(t *testing.T, node *node, prefix string, pattern string, hasHandler bool) {
-	assertNodeValid(t, node, nodeTypeDynamic, prefix, hasHandler)
+func assertNodeDynamic(t *testing.T, node *node, prefix string, pattern string, hasHandler bool, parentNode *node) {
+	assertNodeValid(t, node, nodeTypeDynamic, prefix, hasHandler, parentNode)
 
 	if pattern != node.regexpToString() {
 		t.Errorf("node regExp %s not equals to regExp %s ", node.regexpToString(), pattern)
@@ -71,8 +80,8 @@ func TestInsertChild(t *testing.T) {
 	parseAndInsertSchema(tree, "/path1", "/path1")
 	parseAndInsertSchema(tree, "/path1/path2", "/path2")
 
-	assertNodeStatic(t, tree.root, "/path1", true)
-	assertNodeStatic(t, tree.root.child, "/path2", true)
+	assertNodeStatic(t, tree.root, "/path1", true, nil)
+	assertNodeStatic(t, tree.root.child, "/path2", true, tree.root)
 }
 
 func TestInsertDynamicChild(t *testing.T) {
@@ -81,8 +90,8 @@ func TestInsertDynamicChild(t *testing.T) {
 	parseAndInsertSchema(tree, "/path1/", "/path1/")
 	parseAndInsertSchema(tree, "/path1/{id}", "id")
 
-	assertNodeStatic(t, tree.root, "/path1/", true)
-	assertNodeDynamic(t, tree.root.child, "id", "", true)
+	assertNodeStatic(t, tree.root, "/path1/", true, nil)
+	assertNodeDynamic(t, tree.root.child, "id", "", true, tree.root)
 }
 
 func TestInsertDynamicChildWithRegularExpression(t *testing.T) {
@@ -91,8 +100,8 @@ func TestInsertDynamicChildWithRegularExpression(t *testing.T) {
 	parseAndInsertSchema(tree, "/path1/", "/path1/")
 	parseAndInsertSchema(tree, "/path1/{id:[0-9]+}", "id")
 
-	assertNodeStatic(t, tree.root, "/path1/", true)
-	assertNodeDynamic(t, tree.root.child, "id", "^[0-9]+$", true)
+	assertNodeStatic(t, tree.root, "/path1/", true, nil)
+	assertNodeDynamic(t, tree.root.child, "id", "^[0-9]+$", true, tree.root)
 }
 
 func TestInsertDynamicChildHasNoHandler(t *testing.T) {
@@ -101,9 +110,9 @@ func TestInsertDynamicChildHasNoHandler(t *testing.T) {
 	parseAndInsertSchema(tree, "/path1/", "/path1/")
 	parseAndInsertSchema(tree, "/path1/{id:[0-9]{4}-[0-9]{2}-[0-9]{2}}/", "/")
 
-	assertNodeStatic(t, tree.root, "/path1/", true)
-	assertNodeDynamic(t, tree.root.child, "id", "^[0-9]{4}-[0-9]{2}-[0-9]{2}$", false)
-	assertNodeStatic(t, tree.root.child.stops['/'], "/", true)
+	assertNodeStatic(t, tree.root, "/path1/", true, nil)
+	assertNodeDynamic(t, tree.root.child, "id", "^[0-9]{4}-[0-9]{2}-[0-9]{2}$", false, tree.root)
+	assertNodeStatic(t, tree.root.child.stops['/'], "/", true, tree.root.child)
 }
 
 func TestInsertDynamicChildHasNoHandlerWithSiblings(t *testing.T) {
@@ -113,14 +122,14 @@ func TestInsertDynamicChildHasNoHandlerWithSiblings(t *testing.T) {
 	parseAndInsertSchema(tree, "/path1/{id}/", "/")
 	parseAndInsertSchema(tree, "/path1/{id}-", "-")
 
-	assertNodeStatic(t, tree.root, "/path1/", true)
-	assertNodeDynamic(t, tree.root.child, "id", "", false)
+	assertNodeStatic(t, tree.root, "/path1/", true, nil)
+	assertNodeDynamic(t, tree.root.child, "id", "", false, tree.root)
 
 	if len(tree.root.child.stops) != 2 {
 		t.Errorf("")
 	}
-	assertNodeStatic(t, tree.root.child.stops['/'], "/", true)
-	assertNodeStatic(t, tree.root.child.stops['-'], "-", true)
+	assertNodeStatic(t, tree.root.child.stops['/'], "/", true, tree.root.child)
+	assertNodeStatic(t, tree.root.child.stops['-'], "-", true, tree.root.child)
 }
 
 func TestInsertHandlerIsOnlyOnLeaf(t *testing.T) {
@@ -131,11 +140,11 @@ func TestInsertHandlerIsOnlyOnLeaf(t *testing.T) {
 	parseAndInsertSchema(tree, "/path1/path2/path3", "3")
 	parseAndInsertSchema(tree, "/path1/path2/path4", "4")
 
-	assertNodeStatic(t, tree.root, "/path1", true)
-	assertNodeStatic(t, tree.root.child, "/path2", true)
-	assertNodeStatic(t, tree.root.child.child, "/path", false)
-	assertNodeStatic(t, tree.root.child.child.child, "3", true)
-	assertNodeStatic(t, tree.root.child.child.child.sibling, "4", true)
+	assertNodeStatic(t, tree.root, "/path1", true, nil)
+	assertNodeStatic(t, tree.root.child, "/path2", true, tree.root)
+	assertNodeStatic(t, tree.root.child.child, "/path", false, tree.root.child)
+	assertNodeStatic(t, tree.root.child.child.child, "3", true, tree.root.child.child)
+	assertNodeStatic(t, tree.root.child.child.child.sibling, "4", true, tree.root.child.child)
 }
 
 func TestInsertHandlerNotRemovePreviousHandler(t *testing.T) {
@@ -146,12 +155,12 @@ func TestInsertHandlerNotRemovePreviousHandler(t *testing.T) {
 	parseAndInsertSchema(tree, "/path1/{id}/path3", "3")
 	parseAndInsertSchema(tree, "/path1/{id}/path2/path4", "/path4")
 
-	assertNodeStatic(t, tree.root, "/path1/", false)
-	assertNodeDynamic(t, tree.root.child, "id", "", true)
-	assertNodeStatic(t, tree.root.child.stops['/'], "/path", false)
-	assertNodeStatic(t, tree.root.child.stops['/'].child, "2", true)
-	assertNodeStatic(t, tree.root.child.stops['/'].child.sibling, "3", true)
-	assertNodeStatic(t, tree.root.child.stops['/'].child.child, "/path4", true)
+	assertNodeStatic(t, tree.root, "/path1/", false, nil)
+	assertNodeDynamic(t, tree.root.child, "id", "", true, tree.root)
+	assertNodeStatic(t, tree.root.child.stops['/'], "/path", false, tree.root.child)
+	assertNodeStatic(t, tree.root.child.stops['/'].child, "2", true, tree.root.child.stops['/'])
+	assertNodeStatic(t, tree.root.child.stops['/'].child.sibling, "3", true, tree.root.child.stops['/'])
+	assertNodeStatic(t, tree.root.child.stops['/'].child.child, "/path4", true, tree.root.child.stops['/'].child)
 }
 
 func TestInsertChildOnSibling(t *testing.T) {
@@ -161,10 +170,10 @@ func TestInsertChildOnSibling(t *testing.T) {
 	parseAndInsertSchema(tree, "/path2", "2")
 	parseAndInsertSchema(tree, "/path2/path3", "/path3")
 
-	assertNodeStatic(t, tree.root, "/path", false)
-	assertNodeStatic(t, tree.root.child, "1", true)
-	assertNodeStatic(t, tree.root.child.sibling, "2", true)
-	assertNodeStatic(t, tree.root.child.sibling.child, "/path3", true)
+	assertNodeStatic(t, tree.root, "/path", false, nil)
+	assertNodeStatic(t, tree.root.child, "1", true, tree.root)
+	assertNodeStatic(t, tree.root.child.sibling, "2", true, tree.root)
+	assertNodeStatic(t, tree.root.child.sibling.child, "/path3", true, tree.root.child.sibling)
 }
 
 func TestInsertSiblingOnSibling(t *testing.T) {
@@ -174,10 +183,10 @@ func TestInsertSiblingOnSibling(t *testing.T) {
 	parseAndInsertSchema(tree, "/path2", "2")
 	parseAndInsertSchema(tree, "/path3", "3")
 
-	assertNodeStatic(t, tree.root, "/path", false)
-	assertNodeStatic(t, tree.root.child, "1", true)
-	assertNodeStatic(t, tree.root.child.sibling, "2", true)
-	assertNodeStatic(t, tree.root.child.sibling.sibling, "3", true)
+	assertNodeStatic(t, tree.root, "/path", false, nil)
+	assertNodeStatic(t, tree.root.child, "1", true, tree.root)
+	assertNodeStatic(t, tree.root.child.sibling, "2", true, tree.root)
+	assertNodeStatic(t, tree.root.child.sibling.sibling, "3", true, tree.root)
 }
 
 func TestInsertPrioritisesStaticPaths(t *testing.T) {
@@ -188,12 +197,12 @@ func TestInsertPrioritisesStaticPaths(t *testing.T) {
 	parseAndInsertSchema(tree, "/path1", "1")
 	parseAndInsertSchema(tree, "/path2", "2")
 
-	assertNodeStatic(t, tree.root, "/", false)
-	assertNodeStatic(t, tree.root.child, "path", false)
-	assertNodeStatic(t, tree.root.child.child, "1", true)
-	assertNodeStatic(t, tree.root.child.child.sibling, "2", true)
-	assertNodeDynamic(t, tree.root.child.sibling, "id", "", true)
-	assertNodeDynamic(t, tree.root.child.sibling.sibling, "name", "", true)
+	assertNodeStatic(t, tree.root, "/", false, nil)
+	assertNodeStatic(t, tree.root.child, "path", false, tree.root)
+	assertNodeStatic(t, tree.root.child.child, "1", true, tree.root.child)
+	assertNodeStatic(t, tree.root.child.child.sibling, "2", true, tree.root.child)
+	assertNodeDynamic(t, tree.root.child.sibling, "id", "", true, tree.root)
+	assertNodeDynamic(t, tree.root.child.sibling.sibling, "name", "", true, tree.root)
 }
 
 func TestCreateTreeFromChunksWorks(t *testing.T) {
@@ -206,8 +215,24 @@ func TestCreateTreeFromChunksWorks(t *testing.T) {
 
 	root, leaf := createTreeFromChunks(chunks)
 
-	assertNodeStatic(t, root, "/", false)
-	assertNodeDynamic(t, root.child, "id", "", false)
-	assertNodeStatic(t, root.child.stops['/'], "/abc", false)
-	assertNodeStatic(t, leaf, "/abc", false)
+	assertNodeStatic(t, root, "/", false, nil)
+	assertNodeDynamic(t, root.child, "id", "", false, root)
+	assertNodeStatic(t, root.child.stops['/'], "/abc", false, root.child)
+	assertNodeStatic(t, leaf, "/abc", false, root.child)
+}
+
+func TestInsertPrioritisesStaticPathsKK(t *testing.T) {
+	tree := &tree{}
+
+	parseAndInsertSchema(tree, "/path1/{id}/{name:[a-z]{1,5}}", "")
+	parseAndInsertSchema(tree, "/path1/{name:.*}", "name")
+	parseAndInsertSchema(tree, "/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}", "date")
+	parseAndInsertSchema(tree, "/posts/{id}/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}", "date")
+
+	assertNodeStatic(t, tree.root, "/", false, nil)
+	assertNodeStatic(t, tree.root.child, "p", false, tree.root)
+	assertNodeStatic(t, tree.root.child.child, "ath1/", false, tree.root.child)
+	assertNodeStatic(t, tree.root.child.child.sibling, "osts/", false, tree.root.child)
+	assertNodeDynamic(t, tree.root.child.sibling, "date", "^[0-9]{4}-[0-9]{2}-[0-9]{2}$", true, tree.root)
+	assertNodeDynamic(t, tree.root.child.child.sibling.child, "id", "", false, tree.root.child.child.sibling)
 }


### PR DESCRIPTION
Extracts url parameters from the request on demand instead of creating the parameters bag during tree traversal.

This avoids allocations during path matching and delegates it to the request handler.
Adds a parent node pointer to tree nodes.

Signed-off-by: Jorge Brisa <jorge.br.ib@gmail.com>
Co-authored-by: Jorge Brisa <jorge.br.ib@gmail.com>