### PR TITLE
Load Routes from loader interface

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -15,7 +15,7 @@ func MyHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Hello MyHandler")
 }
 
-func ExampleRegisterHandler_UsingHandlerAlias() {
+func ExampleAddHandler_UsingHandlerAlias() {
 	h, _ := routing.GetHandler("myhandler")
 
 	r, _ := http.NewRequest("GET", "/", nil)
@@ -27,7 +27,7 @@ func ExampleRegisterHandler_UsingHandlerAlias() {
 	// Output: Hello MyHandler
 }
 
-func ExampleRegisterHandler_UsingHandlerCanonicalName() {
+func ExampleAddHandler_UsingHandlerCanonicalName() {
 	h, _ := routing.GetHandler("github.com/golossus/routing_test.MyHandler")
 
 	r, _ := http.NewRequest("GET", "/", nil)

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,40 @@
+package routing_test
+
+import (
+	"fmt"
+	"github.com/golossus/routing"
+	"net/http"
+	"net/http/httptest"
+)
+
+func init() {
+	routing.AddHandler(MyHandler, "myhandler")
+}
+
+func MyHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "Hello MyHandler")
+}
+
+func ExampleRegisterHandler_UsingHandlerAlias() {
+	h, _ := routing.GetHandler("myhandler")
+
+	r, _ := http.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	h(w, r)
+
+	fmt.Println(w.Body.String())
+	// Output: Hello MyHandler
+}
+
+func ExampleRegisterHandler_UsingHandlerCanonicalName() {
+	h, _ := routing.GetHandler("github.com/golossus/routing_test.MyHandler")
+
+	r, _ := http.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	h(w, r)
+
+	fmt.Println(w.Body.String())
+	// Output: Hello MyHandler
+}

--- a/fixtures/routes.json
+++ b/fixtures/routes.json
@@ -1,0 +1,10 @@
+{
+  "routes": [
+    {
+      "name": "get.users",
+      "method": "GET",
+      "schema": "/users",
+      "handler": "get.users.handler"
+    }
+  ]
+}

--- a/fixtures/routes2.json
+++ b/fixtures/routes2.json
@@ -1,0 +1,10 @@
+{
+  "routes": [
+    {
+      "name": "post.users",
+      "method": "POST",
+      "schema": "/users",
+      "handler": "post.users.handler"
+    }
+  ]
+}

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -16,7 +16,8 @@ func validateTokens(expectedTokens, tokens []token, t *testing.T) {
 	}
 }
 
-func TestSimplePath(t *testing.T) {
+
+func TestLexer_ScanAll_SimplePath(t *testing.T) {
 	lexer := newLexer("/path1")
 
 	tokens := lexer.scanAll()
@@ -28,7 +29,7 @@ func TestSimplePath(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestDoubleStatic(t *testing.T) {
+func TestLexer_ScanAll_DoubleStatic(t *testing.T) {
 	lexer := newLexer("/path1/path2")
 
 	tokens := lexer.scanAll()
@@ -42,7 +43,7 @@ func TestDoubleStatic(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestHome(t *testing.T) {
+func TestLexer_ScanAll_Home(t *testing.T) {
 	lexer := newLexer("/")
 
 	tokens := lexer.scanAll()
@@ -53,7 +54,7 @@ func TestHome(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestEndSlash(t *testing.T) {
+func TestLexer_ScanAll_EndSlash(t *testing.T) {
 	lexer := newLexer("/path1/")
 
 	tokens := lexer.scanAll()
@@ -66,7 +67,7 @@ func TestEndSlash(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestWithParameter(t *testing.T) {
+func TestLexer_ScanAll_WithParameter(t *testing.T) {
 	lexer := newLexer("/path1/{id}/path2")
 
 	tokens := lexer.scanAll()
@@ -84,7 +85,7 @@ func TestWithParameter(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestInvalidRoute(t *testing.T) {
+func TestLexer_ScanAll_InvalidRoute(t *testing.T) {
 	lexer := newLexer("/path1/{id/path2")
 
 	tokens := lexer.scanAll()
@@ -101,7 +102,7 @@ func TestInvalidRoute(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestInvalidRouteMissingOpen(t *testing.T) {
+func TestLexer_ScanAll_InvalidRouteMissingOpen(t *testing.T) {
 	lexer := newLexer("/path1/id}/path2")
 
 	tokens := lexer.scanAll()
@@ -118,7 +119,7 @@ func TestInvalidRouteMissingOpen(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestWithEmptyVar(t *testing.T) {
+func TestLexer_ScanAll_WithEmptyVar(t *testing.T) {
 	lexer := newLexer("/path1/{}/path2")
 
 	tokens := lexer.scanAll()
@@ -135,7 +136,7 @@ func TestWithEmptyVar(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestWithDoubleOpenVar(t *testing.T) {
+func TestLexer_ScanAll_WithDoubleOpenVar(t *testing.T) {
 	lexer := newLexer("/path1/{{id}/path2")
 
 	tokens := lexer.scanAll()
@@ -154,7 +155,7 @@ func TestWithDoubleOpenVar(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestWithFinalDoubleOpenVar(t *testing.T) {
+func TestLexer_ScanAll_WithFinalDoubleOpenVar(t *testing.T) {
 	lexer := newLexer("/path1/{id}/path2{")
 
 	tokens := lexer.scanAll()
@@ -173,7 +174,7 @@ func TestWithFinalDoubleOpenVar(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestWithDoubleCloseVar(t *testing.T) {
+func TestLexer_ScanAll_WithDoubleCloseVar(t *testing.T) {
 	lexer := newLexer("/path1/{id}}/path2")
 
 	tokens := lexer.scanAll()
@@ -192,7 +193,7 @@ func TestWithDoubleCloseVar(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestWithStaticValueAfterCloseVar(t *testing.T) {
+func TestLexer_ScanAll_WithStaticValueAfterCloseVar(t *testing.T) {
 	lexer := newLexer("/path1/{id}_name/path2")
 
 	tokens := lexer.scanAll()
@@ -211,7 +212,7 @@ func TestWithStaticValueAfterCloseVar(t *testing.T) {
 	validateTokens(expectedTokens, tokens, t)
 }
 
-func TestWithExpRegular(t *testing.T) {
+func TestLexer_ScanAll_WithExpRegular(t *testing.T) {
 	lexer := newLexer("/path1/{id:[0-9]{4}-[0-9]{4}}")
 
 	tokens := lexer.scanAll()

--- a/loaders/json_file_loader.go
+++ b/loaders/json_file_loader.go
@@ -1,0 +1,62 @@
+package loaders
+
+import (
+	"encoding/json"
+	. "github.com/golossus/routing"
+	"io/ioutil"
+)
+
+// JsonRoutes defines a json collection of routes
+type JsonRoutes struct {
+	Routes []JsonRoute `json:"routes"`
+}
+
+// JsonRoute defines a route json schema
+type JsonRoute struct {
+	Name    string `json:"name"`
+	Schema  string `json:"schema"`
+	Method  string `json:"method"`
+	Handler string `json:"handler"`
+}
+
+// JsonFileLoader type loads routes from Json files
+type JsonFileLoader struct {
+	routes []RouteDef
+}
+
+// Load implements routing.Loader interface
+func (l *JsonFileLoader) Load() []RouteDef {
+	return l.routes
+}
+
+// FromFile loads a list of routes from one or many Json file paths
+func (l *JsonFileLoader) FromFile(files ...string) error {
+
+	for _, path := range files {
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		var rs JsonRoutes
+		err = json.Unmarshal(content, &rs)
+		if err != nil {
+			return err
+		}
+
+		fileRoutes := make([]RouteDef, 0, len(rs.Routes))
+		for _, r := range rs.Routes {
+			fileRoutes = append(fileRoutes, RouteDef{
+				Method:  r.Method,
+				Schema:  r.Schema,
+				Handler: r.Handler,
+				Name:    r.Name,
+			})
+		}
+
+		l.routes = append(l.routes, fileRoutes...)
+
+	}
+
+	return nil
+}

--- a/loaders/json_file_loader_test.go
+++ b/loaders/json_file_loader_test.go
@@ -1,0 +1,41 @@
+package loaders
+
+import (
+	. "github.com/golossus/routing"
+	"reflect"
+	"testing"
+)
+
+func TestJsonFileLoader_LoadFile(t *testing.T) {
+
+	loader := JsonFileLoader{}
+	err := loader.FromFile("../fixtures/routes.json", "../fixtures/routes2.json")
+	if err != nil {
+		t.Error(err)
+	}
+
+	routes := loader.Load()
+	if len(routes) != 2 {
+		t.Errorf("routes length doesn't match")
+	}
+
+	expected := RouteDef{
+		Method:  "GET",
+		Handler: "get.users.handler",
+		Schema:  "/users",
+		Name:    "get.users",
+	}
+	if !reflect.DeepEqual(routes[0], expected) {
+		t.Errorf("route %v not equals to %v", routes[0], expected)
+	}
+
+	expected = RouteDef{
+		Method:  "POST",
+		Handler: "post.users.handler",
+		Schema:  "/users",
+		Name:    "post.users",
+	}
+	if !reflect.DeepEqual(routes[1], expected) {
+		t.Errorf("route %v not equals to %v", routes[1], expected)
+	}
+}

--- a/node_test.go
+++ b/node_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestRegexpToStringWorks(t *testing.T) {
+func TestNode_RegexpToString_Works(t *testing.T) {
 
 	node1 := node{t: nodeTypeStatic}
 	if node1.regexpToString() != "" {
@@ -24,7 +24,7 @@ func TestRegexpToStringWorks(t *testing.T) {
 
 }
 
-func TestIsCatchAllWorks(t *testing.T) {
+func TestNode_IsCatchAll_Works(t *testing.T) {
 
 	node1 := node{t: nodeTypeStatic}
 	if node1.isCatchAll() {
@@ -47,7 +47,7 @@ func TestIsCatchAllWorks(t *testing.T) {
 	}
 }
 
-func TestRegexpEqualsWorks(t *testing.T) {
+func TestNode_RegexpEquals_Works(t *testing.T) {
 
 	node1 := node{t: nodeTypeDynamic, regexp: regexp.MustCompile("[a-z]+")}
 	node2 := node{t: nodeTypeDynamic, regexp: regexp.MustCompile("[0-9]+")}

--- a/parameter_bag.go
+++ b/parameter_bag.go
@@ -13,7 +13,6 @@ type urlParameter struct {
 type URLParameterBag struct {
 	params   []urlParameter
 	capacity uint
-	reverse  bool
 }
 
 func (u *URLParameterBag) add(name, value string) {
@@ -27,9 +26,6 @@ func (u *URLParameterBag) add(name, value string) {
 // GetByName is a method to retrieve a dynamic parameter of the URL using a name. For example 'userId' in /users/{userId}
 func (u *URLParameterBag) GetByName(name string) (string, error) {
 	for i := range u.params {
-		if u.reverse {
-			i = len(u.params) - 1 - i
-		}
 		if u.params[i].name == name {
 			return u.params[i].value, nil
 		}
@@ -45,16 +41,11 @@ func (u *URLParameterBag) GetByIndex(index uint) (string, error) {
 		return "", fmt.Errorf("url parameter at index %d does not exist", i)
 	}
 
-	if u.reverse {
-		i = len(u.params) - 1 - i
-	}
-
 	return u.params[i].value, nil
 }
 
-func newURLParameterBag(capacity uint, reverse bool) URLParameterBag {
+func newURLParameterBag(capacity uint) URLParameterBag {
 	return URLParameterBag{
 		capacity: capacity,
-		reverse:  reverse,
 	}
 }

--- a/parameter_bag_test.go
+++ b/parameter_bag_test.go
@@ -56,19 +56,19 @@ func assertBagParameterNotAtIndex(t *testing.T, bag URLParameterBag, index uint)
 	}
 }
 
-func TestUrlParameterBagEmptyValuesOnCreation(t *testing.T) {
+func TestURLParameterBag_EmptyValuesOnCreation(t *testing.T) {
 	bag := URLParameterBag{}
 
 	assertBagSetting(t, bag, 0, false)
 }
 
-func TestNewUrlParameterBagSetsRightValuesOnCreation(t *testing.T) {
+func TestURLParameterBag_SetsRightValuesOnCreation(t *testing.T) {
 	bag := newURLParameterBag(5, true)
 
 	assertBagSetting(t, bag, 5, true)
 }
 
-func TestUrlParameterBagAddsParameter(t *testing.T) {
+func TestURLParameterBag_Add_Works(t *testing.T) {
 	bag := URLParameterBag{}
 
 	bag.add("param1", "v1")
@@ -76,7 +76,7 @@ func TestUrlParameterBagAddsParameter(t *testing.T) {
 	assertBagParameterContains(t, bag, "param1", "v1")
 }
 
-func TestUrlParameterBagAddsMultipleParameters(t *testing.T) {
+func TestURLParameterBag_GetByName(t *testing.T) {
 	bag := URLParameterBag{}
 
 	bag.add("param1", "v1")
@@ -89,7 +89,7 @@ func TestUrlParameterBagAddsMultipleParameters(t *testing.T) {
 	assertBagParameterNotContains(t, bag, "param4")
 }
 
-func TestUrlParameterBagGetByNameInReverseMode(t *testing.T) {
+func TestURLParameterBag_GetByName_InReverseMode(t *testing.T) {
 	bag := URLParameterBag{reverse: true}
 
 	bag.add("param1", "v1")
@@ -103,7 +103,7 @@ func TestUrlParameterBagGetByNameInReverseMode(t *testing.T) {
 	assertBagParameterNotContains(t, bag, "param4")
 }
 
-func TestUrlParameterBagGetByIndex(t *testing.T) {
+func TestURLParameterBag_GetByIndex(t *testing.T) {
 	bag := URLParameterBag{}
 
 	bag.add("param1", "v1")
@@ -116,7 +116,7 @@ func TestUrlParameterBagGetByIndex(t *testing.T) {
 	assertBagParameterNotAtIndex(t, bag, 3)
 }
 
-func TestUrlParameterBagGetByIndexInReverseMode(t *testing.T) {
+func TestURLParameterBag_GetByIndex_InReverseMode(t *testing.T) {
 	bag := URLParameterBag{reverse: true}
 
 	bag.add("param3", "v3")

--- a/parameter_bag_test.go
+++ b/parameter_bag_test.go
@@ -2,17 +2,13 @@ package routing
 
 import "testing"
 
-func assertBagSetting(t *testing.T, bag URLParameterBag, cap uint, reverse bool) {
+func assertBagSetting(t *testing.T, bag URLParameterBag, cap uint) {
 	if bag.params != nil {
 		t.Errorf("parameter bag params is not nil")
 	}
 
 	if bag.capacity != cap {
 		t.Errorf("parameter bag capacity %d not equals to %d", bag.capacity, cap)
-	}
-
-	if bag.reverse != reverse {
-		t.Errorf("parameter bag reverse mode %t not equals to %t", bag.reverse, reverse)
 	}
 }
 
@@ -59,13 +55,13 @@ func assertBagParameterNotAtIndex(t *testing.T, bag URLParameterBag, index uint)
 func TestURLParameterBag_EmptyValuesOnCreation(t *testing.T) {
 	bag := URLParameterBag{}
 
-	assertBagSetting(t, bag, 0, false)
+	assertBagSetting(t, bag, 0)
 }
 
 func TestURLParameterBag_SetsRightValuesOnCreation(t *testing.T) {
-	bag := newURLParameterBag(5, true)
+	bag := newURLParameterBag(5)
 
-	assertBagSetting(t, bag, 5, true)
+	assertBagSetting(t, bag, 5)
 }
 
 func TestURLParameterBag_Add_Works(t *testing.T) {
@@ -89,39 +85,12 @@ func TestURLParameterBag_GetByName(t *testing.T) {
 	assertBagParameterNotContains(t, bag, "param4")
 }
 
-func TestURLParameterBag_GetByName_InReverseMode(t *testing.T) {
-	bag := URLParameterBag{reverse: true}
-
-	bag.add("param1", "v1")
-	bag.add("param2", "v2")
-	bag.add("param3", "v3")
-	bag.add("param1", "v4")
-
-	assertBagParameterContains(t, bag, "param1", "v4")
-	assertBagParameterContains(t, bag, "param2", "v2")
-	assertBagParameterContains(t, bag, "param3", "v3")
-	assertBagParameterNotContains(t, bag, "param4")
-}
-
 func TestURLParameterBag_GetByIndex(t *testing.T) {
 	bag := URLParameterBag{}
 
 	bag.add("param1", "v1")
 	bag.add("param2", "v2")
 	bag.add("param3", "v3")
-
-	assertBagParameterAtIndex(t, bag, 0, "v1")
-	assertBagParameterAtIndex(t, bag, 1, "v2")
-	assertBagParameterAtIndex(t, bag, 2, "v3")
-	assertBagParameterNotAtIndex(t, bag, 3)
-}
-
-func TestURLParameterBag_GetByIndex_InReverseMode(t *testing.T) {
-	bag := URLParameterBag{reverse: true}
-
-	bag.add("param3", "v3")
-	bag.add("param2", "v2")
-	bag.add("param1", "v1")
 
 	assertBagParameterAtIndex(t, bag, 0, "v1")
 	assertBagParameterAtIndex(t, bag, 1, "v2")

--- a/parser_test.go
+++ b/parser_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestParserValidatesValidPaths(t *testing.T) {
+func TestParser_Parse_ValidatesValidPaths(t *testing.T) {
 	paths := []string{
 		"/",
 		"/path1",
@@ -38,7 +38,7 @@ func TestParserValidatesValidPaths(t *testing.T) {
 	}
 }
 
-func TestParserDoesNotValidateInvalidPaths(t *testing.T) {
+func TestParser_Parse_NoValidateInvalidPaths(t *testing.T) {
 	paths := []string{
 		"",
 		"//",
@@ -78,7 +78,7 @@ func TestParserDoesNotValidateInvalidPaths(t *testing.T) {
 	}
 }
 
-func TestParserReturnsErrorWhenExpressionIsInvalid(t *testing.T) {
+func TestParser_Parse_ReturnsErrorWhenExpressionIsInvalid(t *testing.T) {
 	paths := []string{
 		"/path1/{id:[0-9+}/",
 	}
@@ -93,7 +93,7 @@ func TestParserReturnsErrorWhenExpressionIsInvalid(t *testing.T) {
 	}
 }
 
-func TestParserChechChunks(t *testing.T) {
+func TestParser_Parse_CheckChunks(t *testing.T) {
 	paths := []string{
 		"/",
 		"/path1",

--- a/router.go
+++ b/router.go
@@ -266,3 +266,34 @@ func (r *Router) GenerateURL(name string, params URLParameterBag) (string, error
 	}
 	return url, nil
 }
+
+// RouteDef defines a route definition
+type RouteDef struct {
+	Method  string
+	Schema  string
+	Handler string
+	Name    string
+}
+
+// Loader loads a list routes
+type Loader interface {
+	Load() []RouteDef
+}
+
+// Load registers a list of routes retrieved from a loader
+func (r *Router) Load(loader Loader) error {
+	for _, route := range loader.Load() {
+		handler, err := GetHandler(route.Handler)
+		if err != nil {
+			return err
+		}
+		if route.Name != "" {
+			r.As(route.Name)
+		}
+		err = r.Register(route.Method, route.Schema, handler)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/router.go
+++ b/router.go
@@ -13,7 +13,7 @@ type paramsKey int
 
 var ctxKey paramsKey
 
-var handlers map[string]http.HandlerFunc = make(map[string]http.HandlerFunc)
+var handlers = make(map[string]http.HandlerFunc)
 
 // AddHandler adds an http.HandlerFunc into a list of handlers to be retrieved
 // by name (canonical or alias) on runtime
@@ -41,7 +41,7 @@ func GetHandler(name string) (http.HandlerFunc, error) {
 func GetURLParameters(request *http.Request) URLParameterBag {
 	ctx := request.Context().Value(ctxKey)
 	if ctx == nil {
-		return newURLParameterBag(0, true)
+		return newURLParameterBag(0)
 	}
 
 	leaf := ctx.(*node)
@@ -53,7 +53,7 @@ func GetURLParameters(request *http.Request) URLParameterBag {
 func buildURLParameters(leaf *node, path string, offset int, paramsCount uint) URLParameterBag {
 
 	if leaf == nil {
-		return newURLParameterBag(paramsCount, false)
+		return newURLParameterBag(paramsCount)
 	}
 
 	var paramsBag URLParameterBag

--- a/router_test.go
+++ b/router_test.go
@@ -134,29 +134,29 @@ func TestGetURLParameters(t *testing.T) {
 	mainRouter := Router{}
 	postsRouter := Router{}
 
-	bag := newURLParameterBag(2, false)
+	bag := newURLParameterBag(2)
 	bag.add("id", "100")
 	bag.add("name", "dummy")
 	f := assertRequestHasParameterHandler(t, bag)
 	_ = mainRouter.Register(http.MethodGet, "/path1/{id}/{name:[a-z]{1,5}}", f)
 
-	bag2 := newURLParameterBag(2, false)
+	bag2 := newURLParameterBag(2)
 	bag2.add("name", "dummy/file/src/image.jpg")
 	f2 := assertRequestHasParameterHandler(t, bag2)
 	_ = mainRouter.Register(http.MethodGet, "/path1/{name:.*}", f2)
 
-	bag3 := newURLParameterBag(2, false)
+	bag3 := newURLParameterBag(2)
 	bag3.add("name", "2020-05-05")
 	f3 := assertRequestHasParameterHandler(t, bag3)
 	_ = mainRouter.Register(http.MethodGet, "/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}", f3)
 
-	bag4 := newURLParameterBag(2, false)
+	bag4 := newURLParameterBag(2)
 	bag4.add("id", "123")
 	bag4.add("name", "2020-05-05")
 	f4 := assertRequestHasParameterHandler(t, bag4)
 	_ = postsRouter.Register(http.MethodGet, "/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}", f4)
 
-	mainRouter.Prefix("/posts/{id}", &postsRouter)
+	_ = mainRouter.Prefix("/posts/{id}", &postsRouter)
 
 	assertPathFound(t, mainRouter, "GET", "/path1/100/dummy")
 	assertPathFound(t, mainRouter, "GET", "/path1/dummy/file/src/image.jpg")
@@ -194,7 +194,7 @@ func TestGetURLParameters_ReturnsEmptyBagIfNoContextValueExists(t *testing.T) {
 
 	bag := GetURLParameters(r)
 
-	assertBagSetting(t, bag, 0, true)
+	assertBagSetting(t, bag, 0)
 }
 
 func TestRouter_ServeHTTP_FindsPathsWhenPrefixingRouters(t *testing.T) {
@@ -280,7 +280,7 @@ func TestRouter_As_AssignsRouteNames(t *testing.T) {
 	_ = apiRouter.As("users.account").Get("/users/account", testHandlerFunc)
 	_ = apiRouter.As("users.profile").Get("/users/profile", testHandlerFunc)
 
-	mainRouter.As("api.").Prefix("/api", &apiRouter)
+	_ = mainRouter.As("api.").Prefix("/api", &apiRouter)
 
 	assertRouteNameHasHandler(t, mainRouter, http.MethodGet, "/users", "users.get")
 	assertRouteNameHasHandler(t, mainRouter, http.MethodPost, "/users/create", "users.create")

--- a/router_test.go
+++ b/router_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 var testHandlerFunc = func(response http.ResponseWriter, request *http.Request) {
-	fmt.Fprint(response, request.URL.Path)
+	_, _ = fmt.Fprint(response, request.URL.Path)
 }
 
 var testDummyHandlerFunc = func(response http.ResponseWriter, request *http.Request) {
-	fmt.Fprint(response, "dummy")
+	_, _ = fmt.Fprint(response, "dummy")
 }
 
 func assertPathFound(t *testing.T, router Router, method, path string) {
@@ -72,7 +72,7 @@ func assertRouteNameHasHandler(t *testing.T, mainRouter Router, method, path, ro
 	}
 }
 
-func TestTreeRouterFindsPaths(t *testing.T) {
+func TestRouter_ServeHTTP_FindsPaths(t *testing.T) {
 	router := Router{}
 
 	_ = router.Register(http.MethodGet, "/path1", testHandlerFunc)
@@ -130,7 +130,7 @@ func TestTreeRouterFindsPaths(t *testing.T) {
 	assertPathNotFound(t, router, "GET", "/path1/100/123")
 }
 
-func TestGetURLParamatersBagInHandler(t *testing.T) {
+func TestGetURLParameters(t *testing.T) {
 	mainRouter := Router{}
 	postsRouter := Router{}
 
@@ -164,7 +164,7 @@ func TestGetURLParamatersBagInHandler(t *testing.T) {
 	assertPathFound(t, mainRouter, "GET", "/posts/123/2020-05-05")
 }
 
-func TestVerbsMethodsAreWorking(t *testing.T) {
+func TestRouter_AllVerbs(t *testing.T) {
 	path := "/path1"
 
 	router := Router{}
@@ -189,7 +189,7 @@ func TestVerbsMethodsAreWorking(t *testing.T) {
 	assertPathFound(t, router, "TRACE", path)
 }
 
-func TestGetURLParametersReturnsEmptyBagIfNoContextValueExists(t *testing.T) {
+func TestGetURLParameters_ReturnsEmptyBagIfNoContextValueExists(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/dummy", nil)
 
 	bag := GetURLParameters(r)
@@ -197,7 +197,7 @@ func TestGetURLParametersReturnsEmptyBagIfNoContextValueExists(t *testing.T) {
 	assertBagSetting(t, bag, 0, true)
 }
 
-func TestTreeRouterFindsPathsWhenPrefixingRouters(t *testing.T) {
+func TestRouter_ServeHTTP_FindsPathsWhenPrefixingRouters(t *testing.T) {
 	mainRouter := Router{}
 	_ = mainRouter.Register(http.MethodGet, "/path1", testHandlerFunc)
 	_ = mainRouter.Register(http.MethodGet, "/path2", testHandlerFunc)
@@ -265,7 +265,7 @@ func TestTreeRouterFindsPathsWhenPrefixingRouters(t *testing.T) {
 	assertPathNotFound(t, mainRouter, "GET", "/path1/100/123")
 }
 
-func TestTreeRouterAssignsRouteNames(t *testing.T) {
+func TestRouter_As_AssignsRouteNames(t *testing.T) {
 	mainRouter := Router{}
 
 	_ = mainRouter.As("users.get").Get("/users", testHandlerFunc)
@@ -292,7 +292,7 @@ func TestTreeRouterAssignsRouteNames(t *testing.T) {
 	assertRouteNameHasHandler(t, mainRouter, http.MethodGet, "/api/users/profile", "api.users.profile")
 }
 
-func TestTreeRouterGenerateValidRoutes(t *testing.T) {
+func TestRouter_GenerateURL_GenerateValidRoutes(t *testing.T) {
 	mainRouter := Router{}
 
 	_ = mainRouter.As("path1").Register(http.MethodGet, "/path1", testHandlerFunc)
@@ -333,7 +333,7 @@ func (l *sliceLoader) Load() []RouteDef {
 	return x
 }
 
-func TestRouterLoadRegisterRoutes(t *testing.T) {
+func TestRouter_Load_RegisterRoutes(t *testing.T) {
 	AddHandler(testHandlerFunc, "users.Handler")
 
 	router := NewRouter()
@@ -348,7 +348,7 @@ func TestRouterLoadRegisterRoutes(t *testing.T) {
 	assertPathFound(t, router, "GET", "/users")
 }
 
-func TestRouterLoadFailsWhenHandlerNoExists(t *testing.T) {
+func TestRouter_Load_FailsWhenHandlerNoExists(t *testing.T) {
 	AddHandler(testHandlerFunc, "users.Handler")
 
 	router := NewRouter()
@@ -361,7 +361,7 @@ func TestRouterLoadFailsWhenHandlerNoExists(t *testing.T) {
 	}
 }
 
-func TestRouterLoadFailsWhenSchemaIsInvalid(t *testing.T) {
+func TestRouter_Load_FailsWhenSchemaIsInvalid(t *testing.T) {
 	AddHandler(testHandlerFunc, "users.Handler")
 
 	router := NewRouter()

--- a/tree.go
+++ b/tree.go
@@ -40,7 +40,7 @@ func combine(tree1 *node, tree2 *node) *node {
 				return tree1
 			}
 
-			for k, _ := range tree2.stops {
+			for k := range tree2.stops {
 				tree2.stops[k].parent = tree1
 			}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -74,7 +74,7 @@ func assertNodeDynamic(t *testing.T, node *node, prefix string, pattern string, 
 	}
 }
 
-func TestInsertChild(t *testing.T) {
+func TestTree_Insert_Child(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/path1", "/path1")
@@ -84,7 +84,7 @@ func TestInsertChild(t *testing.T) {
 	assertNodeStatic(t, tree.root.child, "/path2", true, tree.root)
 }
 
-func TestInsertDynamicChild(t *testing.T) {
+func TestTree_Insert_DynamicChild(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/path1/", "/path1/")
@@ -94,7 +94,7 @@ func TestInsertDynamicChild(t *testing.T) {
 	assertNodeDynamic(t, tree.root.child, "id", "", true, tree.root)
 }
 
-func TestInsertDynamicChildWithRegularExpression(t *testing.T) {
+func TestTree_Insert_DynamicChildWithRegularExpression(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/path1/", "/path1/")
@@ -104,7 +104,7 @@ func TestInsertDynamicChildWithRegularExpression(t *testing.T) {
 	assertNodeDynamic(t, tree.root.child, "id", "^[0-9]+$", true, tree.root)
 }
 
-func TestInsertDynamicChildHasNoHandler(t *testing.T) {
+func TestTree_Insert_DynamicChildHasNoHandler(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/path1/", "/path1/")
@@ -115,7 +115,7 @@ func TestInsertDynamicChildHasNoHandler(t *testing.T) {
 	assertNodeStatic(t, tree.root.child.stops['/'], "/", true, tree.root.child)
 }
 
-func TestInsertDynamicChildHasNoHandlerWithSiblings(t *testing.T) {
+func TestTree_Insert_DynamicChildHasNoHandlerWithSiblings(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/path1/", "/path1/")
@@ -132,7 +132,7 @@ func TestInsertDynamicChildHasNoHandlerWithSiblings(t *testing.T) {
 	assertNodeStatic(t, tree.root.child.stops['-'], "-", true, tree.root.child)
 }
 
-func TestInsertHandlerIsOnlyOnLeaf(t *testing.T) {
+func TestTree_Insert_HandlerIsOnlyOnLeaf(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/path1", "/path1")
@@ -147,7 +147,7 @@ func TestInsertHandlerIsOnlyOnLeaf(t *testing.T) {
 	assertNodeStatic(t, tree.root.child.child.child.sibling, "4", true, tree.root.child.child)
 }
 
-func TestInsertHandlerNotRemovePreviousHandler(t *testing.T) {
+func TestTree_Insert_HandlerNotRemovePreviousHandler(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/path1/{id}", "id")
@@ -163,7 +163,7 @@ func TestInsertHandlerNotRemovePreviousHandler(t *testing.T) {
 	assertNodeStatic(t, tree.root.child.stops['/'].child.child, "/path4", true, tree.root.child.stops['/'].child)
 }
 
-func TestInsertChildOnSibling(t *testing.T) {
+func TestTree_Insert_ChildOnSibling(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/path1", "1")
@@ -176,7 +176,7 @@ func TestInsertChildOnSibling(t *testing.T) {
 	assertNodeStatic(t, tree.root.child.sibling.child, "/path3", true, tree.root.child.sibling)
 }
 
-func TestInsertSiblingOnSibling(t *testing.T) {
+func TestTree_Insert_SiblingOnSibling(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/path1", "1")
@@ -189,7 +189,7 @@ func TestInsertSiblingOnSibling(t *testing.T) {
 	assertNodeStatic(t, tree.root.child.sibling.sibling, "3", true, tree.root)
 }
 
-func TestInsertPrioritisesStaticPaths(t *testing.T) {
+func TestTree_Insert_PrioritisesStaticPaths(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/{id}", "id")
@@ -205,7 +205,7 @@ func TestInsertPrioritisesStaticPaths(t *testing.T) {
 	assertNodeDynamic(t, tree.root.child.sibling.sibling, "name", "", true, tree.root)
 }
 
-func TestCreateTreeFromChunksWorks(t *testing.T) {
+func TestCreateTreeFromChunks(t *testing.T) {
 
 	chunks := []chunk{
 		{t: tChunkStatic, v: "/"},
@@ -221,7 +221,7 @@ func TestCreateTreeFromChunksWorks(t *testing.T) {
 	assertNodeStatic(t, leaf, "/abc", false, root.child)
 }
 
-func TestInsertPrioritisesStaticPathsKK(t *testing.T) {
+func TestTree_Insert_PrioritisesStaticPathsKK(t *testing.T) {
 	tree := &tree{}
 
 	parseAndInsertSchema(tree, "/path1/{id}/{name:[a-z]{1,5}}", "")

--- a/tree_test.go
+++ b/tree_test.go
@@ -10,7 +10,7 @@ import (
 
 func nodePrefixHandler(prefix string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, prefix)
+		_, _ = fmt.Fprint(w, prefix)
 	}
 }
 


### PR DESCRIPTION
Implement Load function to register a list of routes by means of a loader
Adds a map of string keys to handlers to store registered handlers 
Adds a testable example of registering handlers during package initialization
Adds a JsonFileLoader to load routes from JSON files

Refactor
- Rename all test methods to upper snake case
- Remove reverse mode in URLParameterBag

