### PR TITLE
feat: adds MatchingOptions type for registering routes

### DIFF
--- a/router.go
+++ b/router.go
@@ -102,81 +102,21 @@ func (r *Router) ServeHTTP(response http.ResponseWriter, request *http.Request) 
 	leaf.handler(response, request)
 }
 
-// As method sets a name for the next registered route
+// As method sets a name for the next registered route.
+//
+// Deprecated: MatchingOptions should be used instead and will have preference
+// over this method. It will be deleted on minor version after v1.2.0
 func (r *Router) As(asName string) *Router {
 	r.asName = asName
 	return r
 }
 
-// Head is a method to register a new HEAD route in the router.
-func (r *Router) Head(path string, handler http.HandlerFunc) error {
-	return r.Register(http.MethodHead, path, handler)
-}
-
-// Get is a method to register a new GET route in the router.
-func (r *Router) Get(path string, handler http.HandlerFunc) error {
-	return r.Register(http.MethodGet, path, handler)
-}
-
-// Post is a method to register a new POST route in the router.
-func (r *Router) Post(path string, handler http.HandlerFunc) error {
-	return r.Register(http.MethodPost, path, handler)
-}
-
-// Put is a method to register a new PUT route in the router.
-func (r *Router) Put(path string, handler http.HandlerFunc) error {
-	return r.Register(http.MethodPut, path, handler)
-}
-
-// Patch is a method to register a new PATCH route in the router.
-func (r *Router) Patch(path string, handler http.HandlerFunc) error {
-	return r.Register(http.MethodPatch, path, handler)
-}
-
-// Delete is a method to register a new DELETE route in the router.
-func (r *Router) Delete(path string, handler http.HandlerFunc) error {
-	return r.Register(http.MethodDelete, path, handler)
-}
-
-// Connect is a method to register a new CONNECT route in the router.
-func (r *Router) Connect(path string, handler http.HandlerFunc) error {
-	return r.Register(http.MethodConnect, path, handler)
-}
-
-// Options is a method to register a new OPTIONS route in the router.
-func (r *Router) Options(path string, handler http.HandlerFunc) error {
-	return r.Register(http.MethodOptions, path, handler)
-}
-
-// Trace is a method to register a new TRACE route in the router.
-func (r *Router) Trace(path string, handler http.HandlerFunc) error {
-	return r.Register(http.MethodTrace, path, handler)
-}
-
-// Any is a method to register a new route with all the verbs.
-func (r *Router) Any(path string, handler http.HandlerFunc) error {
-	kvs := [9]string{
-		http.MethodHead,
-		http.MethodGet,
-		http.MethodPost,
-		http.MethodPut,
-		http.MethodPatch,
-		http.MethodDelete,
-		http.MethodConnect,
-		http.MethodOptions,
-		http.MethodTrace,
-	}
-	for _, verb := range kvs {
-		if err := r.Register(verb, path, handler); err != nil {
-			return err
-		}
-	}
-
-	return nil
+type MatchingOptions struct {
+	name string
 }
 
 // Register adds a new route in the router
-func (r *Router) Register(verb, path string, handler http.HandlerFunc) error {
+func (r *Router) Register(verb, path string, handler http.HandlerFunc, options ...MatchingOptions) error {
 	parser := newParser(path)
 	_, err := parser.parse()
 	if err != nil {
@@ -197,16 +137,88 @@ func (r *Router) Register(verb, path string, handler http.HandlerFunc) error {
 
 	leaf := r.trees[verb].insert(parser.chunks, handler)
 
-	if r.asName != "" {
-		r.routes[r.asName] = leaf
-		r.asName = ""
+	rname := r.asName
+	if len(options) > 0 {
+		rname = options[0].name
+	}
+
+	if rname != "" {
+		r.routes[rname] = leaf
+	}
+	r.asName = ""
+
+	return nil
+}
+
+// Head is a method to register a new HEAD route in the router.
+func (r *Router) Head(path string, handler http.HandlerFunc, options ...MatchingOptions) error {
+	return r.Register(http.MethodHead, path, handler, options...)
+}
+
+// Get is a method to register a new GET route in the router.
+func (r *Router) Get(path string, handler http.HandlerFunc, options ...MatchingOptions) error {
+	return r.Register(http.MethodGet, path, handler, options...)
+}
+
+// Post is a method to register a new POST route in the router.
+func (r *Router) Post(path string, handler http.HandlerFunc, options ...MatchingOptions) error {
+	return r.Register(http.MethodPost, path, handler, options...)
+}
+
+// Put is a method to register a new PUT route in the router.
+func (r *Router) Put(path string, handler http.HandlerFunc, options ...MatchingOptions) error {
+	return r.Register(http.MethodPut, path, handler, options...)
+}
+
+// Patch is a method to register a new PATCH route in the router.
+func (r *Router) Patch(path string, handler http.HandlerFunc, options ...MatchingOptions) error {
+	return r.Register(http.MethodPatch, path, handler, options...)
+}
+
+// Delete is a method to register a new DELETE route in the router.
+func (r *Router) Delete(path string, handler http.HandlerFunc, options ...MatchingOptions) error {
+	return r.Register(http.MethodDelete, path, handler, options...)
+}
+
+// Connect is a method to register a new CONNECT route in the router.
+func (r *Router) Connect(path string, handler http.HandlerFunc, options ...MatchingOptions) error {
+	return r.Register(http.MethodConnect, path, handler, options...)
+}
+
+// Options is a method to register a new OPTIONS route in the router.
+func (r *Router) Options(path string, handler http.HandlerFunc, options ...MatchingOptions) error {
+	return r.Register(http.MethodOptions, path, handler, options...)
+}
+
+// Trace is a method to register a new TRACE route in the router.
+func (r *Router) Trace(path string, handler http.HandlerFunc, options ...MatchingOptions) error {
+	return r.Register(http.MethodTrace, path, handler, options...)
+}
+
+// Any is a method to register a new route with all the verbs.
+func (r *Router) Any(path string, handler http.HandlerFunc, options ...MatchingOptions) error {
+	kvs := [9]string{
+		http.MethodHead,
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+		http.MethodConnect,
+		http.MethodOptions,
+		http.MethodTrace,
+	}
+	for _, verb := range kvs {
+		if err := r.Register(verb, path, handler, options...); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
 // Prefix combines two routers under a custom path prefix
-func (r *Router) Prefix(path string, router *Router) error {
+func (r *Router) Prefix(path string, router *Router, options ...MatchingOptions) error {
 	parser := newParser(path)
 	_, err := parser.parse()
 	if err != nil {
@@ -234,8 +246,13 @@ func (r *Router) Prefix(path string, router *Router) error {
 		r.trees[verb].root = combine(r.trees[verb].root, rootNew)
 	}
 
+	rname := r.asName
+	if len(options) > 0 {
+		rname = options[0].name
+	}
+
 	for name, leaf := range router.routes {
-		r.routes[fmt.Sprintf("%s%s", r.asName, name)] = leaf
+		r.routes[fmt.Sprintf("%s%s", rname, name)] = leaf
 	}
 	r.asName = ""
 
@@ -260,12 +277,12 @@ func (r *Router) GenerateURL(name string, params URLParameterBag) (string, error
 
 func getUri(node *node, url *strings.Builder, params URLParameterBag) error {
 
-	if node == nil{
+	if node == nil {
 		return nil
 	}
 
 	err := getUri(node.parent, url, params)
-	if err != nil{
+	if err != nil {
 		return err
 	}
 

--- a/router_test.go
+++ b/router_test.go
@@ -292,6 +292,60 @@ func TestRouter_As_AssignsRouteNames(t *testing.T) {
 	assertRouteNameHasHandler(t, mainRouter, http.MethodGet, "/api/users/profile", "api.users.profile")
 }
 
+func TestRouter_MatchingOptions_AssignsRouteNames(t *testing.T) {
+	mainRouter := Router{}
+
+	_ = mainRouter.Get("/users", testHandlerFunc, MatchingOptions{"users.get"})
+	_ = mainRouter.Post("/users", testHandlerFunc, MatchingOptions{"users.create"})
+	_ = mainRouter.Post("/users/create", testHandlerFunc, MatchingOptions{"users.create"})
+	_ = mainRouter.Put("/users/{id}", testHandlerFunc, MatchingOptions{"users.update"})
+	_ = mainRouter.Delete("/users/{id}", testDummyHandlerFunc, MatchingOptions{"users.delete"})
+	_ = mainRouter.Delete("/users/{id}", testHandlerFunc, MatchingOptions{"users.softDelete"})
+	_ = mainRouter.Get("/users/profile", testDummyHandlerFunc)
+
+	apiRouter := Router{}
+	_ = apiRouter.Get("/users/account", testHandlerFunc, MatchingOptions{"users.account"})
+	_ = apiRouter.Get("/users/profile", testHandlerFunc, MatchingOptions{"users.profile"})
+
+	_ = mainRouter.Prefix("/api", &apiRouter, MatchingOptions{"api."})
+
+	assertRouteNameHasHandler(t, mainRouter, http.MethodGet, "/users", "users.get")
+	assertRouteNameHasHandler(t, mainRouter, http.MethodPost, "/users/create", "users.create")
+	assertRouteNameHasHandler(t, mainRouter, http.MethodPut, "/users/100", "users.update")
+	assertRouteNameHasHandler(t, mainRouter, http.MethodDelete, "/users/100", "users.delete")
+	assertRouteNameHasHandler(t, mainRouter, http.MethodDelete, "/users/100", "users.softDelete")
+
+	assertRouteNameHasHandler(t, mainRouter, http.MethodGet, "/api/users/account", "api.users.account")
+	assertRouteNameHasHandler(t, mainRouter, http.MethodGet, "/api/users/profile", "api.users.profile")
+}
+
+func TestRouter_MatchingOptions_AssignsRouteNamesOverAsMethod(t *testing.T) {
+	mainRouter := Router{}
+
+	_ = mainRouter.As("users.getAs").Get("/users", testHandlerFunc, MatchingOptions{"users.get"})
+	_ = mainRouter.As("users.createAs").Post("/users", testHandlerFunc, MatchingOptions{"users.create"})
+	_ = mainRouter.As("users.createAs").Post("/users/create", testHandlerFunc, MatchingOptions{"users.create"})
+	_ = mainRouter.As("users.updateAs").Put("/users/{id}", testHandlerFunc, MatchingOptions{"users.update"})
+	_ = mainRouter.As("users.deleteAs").Delete("/users/{id}", testDummyHandlerFunc, MatchingOptions{"users.delete"})
+	_ = mainRouter.As("users.softDeleteAs").Delete("/users/{id}", testHandlerFunc, MatchingOptions{"users.softDelete"})
+	_ = mainRouter.Get("/users/profile", testDummyHandlerFunc)
+
+	apiRouter := Router{}
+	_ = apiRouter.Get("/users/account", testHandlerFunc, MatchingOptions{"users.account"})
+	_ = apiRouter.Get("/users/profile", testHandlerFunc, MatchingOptions{"users.profile"})
+
+	_ = mainRouter.Prefix("/api", &apiRouter, MatchingOptions{"api."})
+
+	assertRouteNameHasHandler(t, mainRouter, http.MethodGet, "/users", "users.get")
+	assertRouteNameHasHandler(t, mainRouter, http.MethodPost, "/users/create", "users.create")
+	assertRouteNameHasHandler(t, mainRouter, http.MethodPut, "/users/100", "users.update")
+	assertRouteNameHasHandler(t, mainRouter, http.MethodDelete, "/users/100", "users.delete")
+	assertRouteNameHasHandler(t, mainRouter, http.MethodDelete, "/users/100", "users.softDelete")
+
+	assertRouteNameHasHandler(t, mainRouter, http.MethodGet, "/api/users/account", "api.users.account")
+	assertRouteNameHasHandler(t, mainRouter, http.MethodGet, "/api/users/profile", "api.users.profile")
+}
+
 func TestRouter_GenerateURL_GenerateValidRoutes(t *testing.T) {
 	mainRouter := Router{}
 
@@ -311,7 +365,6 @@ func TestRouter_GenerateURL_GenerateValidRoutes(t *testing.T) {
 	assertRouteIsGenerated(t, mainRouter, "date", "/2020-05-05", map[string]string{"date": "2020-05-05"})
 	assertRouteIsGenerated(t, mainRouter, "posts.id.date", "/posts/10/2020-05-05", map[string]string{"id": "10", "date": "2020-05-05"})
 }
-
 
 func assertRouteIsGenerated(t *testing.T, mainRouter Router, name, url string, params map[string]string) {
 	bag := URLParameterBag{}


### PR DESCRIPTION
Adds MathingOptions type used as optional parameter to register routes.
Deprecates As method on the router type. To be removed in the next minor version.

Co-authored-by: Jorge Brisa <jorge.br.ib@gmail.com>